### PR TITLE
Fix ignoring parameters on actions shutdown and restart

### DIFF
--- a/AssistantComputerControl/Actions.cs
+++ b/AssistantComputerControl/Actions.cs
@@ -116,12 +116,10 @@ namespace AssistantComputerControl {
             if (parameter != null) {
                 if (parameter == "abort") {
                     shutdownParameters = "abort";
+                } else if (parameter.Contains("/t") || parameter.Contains("-t")) {
+                    shutdownParameters = (!parameter.Contains("/s") && !parameter.Contains("-s") ? "/s " : "") + parameter;
                 } else {
-                    if (parameter.Contains("/t") || parameter.Contains("-t")) {
-                        shutdownParameters = !parameter.Contains("/s") && !parameter.Contains("-s") ? "/s " : "" + parameter;
-                    } else {
-                        shutdownParameters = !parameter.Contains("/s") && !parameter.Contains("-s") ? "/s " : "" + parameter + " /t 0";
-                    }
+                    shutdownParameters = (!parameter.Contains("/s") && !parameter.Contains("-s") ? "/s " : "") + parameter + " /t 0";
                 }
             }
 
@@ -148,12 +146,10 @@ namespace AssistantComputerControl {
             if (parameter != null) {
                 if (parameter == "abort") {
                     restartParameters = "abort";
+                } else if (parameter.Contains("/t") || parameter.Contains("-t")) {
+                    restartParameters = (!parameter.Contains("/r") && !parameter.Contains("-r") ? "/r " : "") + parameter;
                 } else {
-                    if (parameter.Contains("/t") || parameter.Contains("-t")) {
-                        restartParameters = !parameter.Contains("/r") && !parameter.Contains("-r") ? "/r " : "" + parameter;
-                    } else {
-                        restartParameters = !parameter.Contains("/r") && !parameter.Contains("-r") ? "/r " : "" + parameter + " /t 0";
-                    }
+                    restartParameters = (!parameter.Contains("/r") && !parameter.Contains("-r") ? "/r " : "") + parameter + " /t 0";
                 }
             }
             if (MainProgram.testingAction) {


### PR DESCRIPTION
In the current state the parameters are ignored for the shutdown and restart actions if the user omits /s, -s or /r, -r respectively.

Input file content:
`restart:/f`

Output command:
`shutdown /r`

As you can see, we are missing both `/f` and `/t 0` in the output. This is not according [the manual](https://acc.readme.io/docs/actions#section--restart-):
> Parameters are added after the /r parameter: /r %parameters%. If /t is not a part of the parameter /t 0 will be appended after the ACC-parameter: /r %parameter% /t 0

This pull fixes the output so that we perform:
`shutdown /r /f /t 0`

The same goes for the shutdown command. It took me a while to figure out why my custom action wasn't working. :)