### PR TITLE
Removed uppercasing in write_out action

### DIFF
--- a/AssistantComputerControl/Actions.cs
+++ b/AssistantComputerControl/Actions.cs
@@ -497,7 +497,7 @@ namespace AssistantComputerControl {
             int i = 0;
             string writtenString = "";
             foreach (char c in parameter) {
-                char toWrite = (i == 0 && Properties.Settings.Default.WriteOutUCFirst ? Char.ToUpper(c) : c);
+                char toWrite = c;
                 if (!MainProgram.testingAction) PressKey(toWrite);
                 writtenString += toWrite;
 


### PR DESCRIPTION
When using the write_out action, the first letter is capitalized, which is a little annoying for some uses, so I deleted the code that does that.