### PR TITLE
Added SPACE key shortcut (fixes #85).

### DIFF
--- a/AssistantComputerControl/Actions.cs
+++ b/AssistantComputerControl/Actions.cs
@@ -97,6 +97,7 @@ namespace AssistantComputerControl {
             { "Keypad_subtract",    "{SUBTRACT}"},
             { "Keypad_multiply",    "{MULTIPLY}"},
             { "Keypad_divide",      "{DIVIDE}"},
+            { "SPACE",              " "},
             { "SHIFT",              "+"},
             { "CTRL",               "^"},
             { "ALT",                "%"}


### PR DESCRIPTION
Adding support for using the `SPACE` key in `key_shortcut`, fixing #85.
This was actually super easy to do, literally all I had to do was add `{"SPACE", " "}` in the list of accepted keys.