### PR TITLE
potential google drive work around

### DIFF
--- a/AssistantComputerControl/MainProgram.cs
+++ b/AssistantComputerControl/MainProgram.cs
@@ -265,9 +265,10 @@ namespace AssistantComputerControl {
                     Path = CheckPath(),
                     NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite
                                         | NotifyFilters.FileName | NotifyFilters.DirectoryName,
-                    Filter = "*." + Properties.Settings.Default.ActionFileExtension,
+                    Filter = "*" + Properties.Settings.Default.ActionFileExtension,
                     EnableRaisingEvents = true
                 };
+                watcher.IncludeSubdirectories = true;
                 watcher.Changed += new FileSystemEventHandler(new ActionChecker().FileFound);
                 watcher.Created += new FileSystemEventHandler(new ActionChecker().FileFound);
                 watcher.Renamed += new RenamedEventHandler(new ActionChecker().FileFound);
@@ -555,7 +556,7 @@ namespace AssistantComputerControl {
 
         public static void SetupListener() {
             watcher.Path = CheckPath();
-            watcher.Filter = "*." + Properties.Settings.Default.ActionFileExtension;
+            watcher.Filter = "*" + Properties.Settings.Default.ActionFileExtension;
             TaskSchedulerSetup();
             DoDebug("Listener modified");
         }

--- a/AssistantComputerControl/actionChecker.cs
+++ b/AssistantComputerControl/actionChecker.cs
@@ -117,7 +117,10 @@ namespace AssistantComputerControl {
 
         [STAThread]
         public void FileFound(object source, FileSystemEventArgs e) {
-            ProcessFile(e.FullPath);
+            var extension = Path.GetExtension(e.FullPath).ToUpper();
+            if (extension == Properties.Settings.Default.ActionFileExtension.ToUpper()) {
+                ProcessFile(e.FullPath);
+            }
         }
 
         [STAThread]


### PR DESCRIPTION
GDrive seems to cache the file locally to `C:\Users\_user_\AppData\Local\Google\DriveFS\_AccountNumber_\content_cache`.

Problem1: They're stored behind 2 sub-folders.
Solution: set `IncludeSubdirectories` to true.

Problem2: File doesn't have an extension.
Solution: Include all files if extension not specified and do further filtering in eventhandler.

So if people wants to use GDrive, they would have to set:
    **Action folderpath** to `C:\Users\_user_\AppData\Local\Google\DriveFS\_AccountNumber_\content_cache`.
and leave **Action file extension** empty.

For others, they would have to include `.` in **Action file extension**. So `.txt` instead of `txt`.

Things like `this.actionFileExtension.Text` and `string listeningInText` are not changed to include/exclude `.` in this commit.
